### PR TITLE
Escape characters in javascript comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const getStdin  = require('get-stdin');
 
 const commentTypes = {
   md:   { begin: '<!---', end: '--->' },
-  js:   { begin: '/*', end: '*/' },
+  js:   { begin: '/\\*', end: '\\*/' },
   html: { begin: '<!--', end: '-->' },
 };
 


### PR DESCRIPTION
Added escape of * characters in javascript comments parsing so the RegEx does not throw a SyntaxError.